### PR TITLE
docs: :memo: Update edit link 

### DIFF
--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -13,7 +13,7 @@ export const en = defineConfig({
         },
 
         editLink: {
-            pattern: 'https://github.com/smart-doc-group/smart-doc-group.github.io/edit/main/docs/:path',
+            pattern: 'https://github.com/smart-doc-group/smart-doc-group.github.io/edit/master/docs/:path',
             text: 'Edit this page on GitHub'
         },
 

--- a/docs/.vitepress/config/zh.ts
+++ b/docs/.vitepress/config/zh.ts
@@ -14,7 +14,7 @@ export const zh = defineConfig({
         },
 
         editLink: {
-            pattern: 'https://github.com/smart-doc-group/smart-doc-group.github.io/edit/main/docs/:path',
+            pattern: 'https://github.com/smart-doc-group/smart-doc-group.github.io/edit/master/docs/:path',
             text: '在 GitHub 上编辑此页面'
         },
 

--- a/docs/zh/guide/plugins/gradle.md
+++ b/docs/zh/guide/plugins/gradle.md
@@ -158,7 +158,7 @@ gradle javadocAdoc
 #### 使用 IDEA
 当你使用`Idea`时，可以通过`Gradle Helper`插件选择生成何种文档。
 
-![idea中smart-doc-gradle插件使用](https://github.com/smart-doc-group/smart-doc-group.github.io/raw/master/docs/_images/idea-gradle-plugin.png "usage.png")
+![idea中smart-doc-gradle插件使用](/assets/idea-gradle-plugin.png "usage.png")
 
 ## 插件源码
 


### PR DESCRIPTION
docs: :memo: Update edit link pattern and image paths in docs config- Change the edit link pattern from 'main' to 'master' branch in both English and Chinese configuration files to reflect the correct GitHub repository reference.
- Update the image path in the Gradle plugin debugging section to point to the
  correct location within the documentation assets.



#97 