### PR TITLE
feat: Add the 'enumConvertor' configuration, default 'false'

### DIFF
--- a/docs/en/guide/advanced/config.md
+++ b/docs/en/guide/advanced/config.md
@@ -64,6 +64,7 @@
 |                                `showValidation`                                | `3.0.3` |    ❌     | `Boolean`      |       `true`        | `showValidation` is used to control whether `smart-doc` extracts the JSR validation information of fields for display in the documentation.                                                                                                                                                                                                                                                                                                                                                                                  |
 |                                    `jmeter`                                    | `3.0.4` |    ❌     | `Object`       |                     | Custom Configurations for JMeter Performance Test Script Generation                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 |                            `addDefaultHttpStatuses`                            | `3.0.5` |    ❌     | `Boolean`      |       `false`       | When generating documentation, consider whether to include the default HTTP status codes from frameworks such as Spring MVC's default `500` and `404` errors. Currently, only the generation of `OpenAPI` documentation supports this feature.                                                                                                                                                                                                                                                                               |
+|                                 `enumConvertor`                                | `3.1.0` |    ❌     | `Boolean`      |       `false`       | In the header/path/query request mode, whether to enable the enumeration converter, The default value is false. <br/>If true, the enumeration value is parsed as an enumeration example value. <br/>If false, take the enumeration name as the enumeration example value                                                                                                                                                                                                                                                               |
 
 ```json
 {
@@ -246,7 +247,8 @@
     "jmeter": {
         "addPrometheusListener": true
     },
-    "addDefaultHttpStatuses": true
+    "addDefaultHttpStatuses": true,
+    "enumConvertor": false
 }
 ```
 ## packageFilters

--- a/docs/zh/guide/advanced/config.md
+++ b/docs/zh/guide/advanced/config.md
@@ -68,6 +68,7 @@
 |                       `showValidation`                        | `3.0.3` | ❌  |   `Boolean`    |       `true`        | `showValidation`用于控制`smart-doc`是否提取JSR字段验证信息展示到文档中                                                                                                                                                                         |
 |                           `jmeter`                            | `3.0.4` | ❌  |    `Object`    |                     | 生成`JMeter`性能测试脚本一些配置。                                                                                                                                                                                                      |
 |                   `addDefaultHttpStatuses`                    | `3.0.5` | ❌  |   `Boolean`    |       `false`       | 生成文档时是否添加框架默认的`http`状态码，例如`Spring MVC`默认的`500`和`404`, 当前只有生成`OenAPI`文档时支持。                                                                                                                                                 |
+|                       `enumConvertor`                         | `3.1.0` | ❌  |   `Boolean`    |       `false`       | 在 header/path/query 请求类型下，是否启用枚举转换器，默认值为false。<br/>如果为true，则解析enumValue作为枚举示例值。<br/>如果为false，则以enumName作为枚举示例值                                                                                                                                              |
 
 ```json
 {
@@ -250,7 +251,8 @@
     "jmeter": {
         "addPrometheusListener": true
     },
-    "addDefaultHttpStatuses": true
+    "addDefaultHttpStatuses": true,
+    "enumConvertor": false
 }
 ```
 


### PR DESCRIPTION
In the header/path/query request mode, whether to enable the enumeration converter, the default value is false. 
1. If true, the enumeration value is parsed as an enumeration example value. 
2. If false, take the enumeration name as the enumeration example value

PR: https://github.com/TongchengOpenSource/smart-doc/pull/989