### PR TITLE
feat(config): :sparkles:  add openApiTagNameType configuration for OpenAPI documentation

### DIFF
--- a/docs/en/guide/advanced/config.md
+++ b/docs/en/guide/advanced/config.md
@@ -65,6 +65,7 @@
 |                                    `jmeter`                                    | `3.0.4` |    ❌     | `Object`       |                     | Custom Configurations for JMeter Performance Test Script Generation                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 |                            `addDefaultHttpStatuses`                            | `3.0.5` |    ❌     | `Boolean`      |       `false`       | When generating documentation, consider whether to include the default HTTP status codes from frameworks such as Spring MVC's default `500` and `404` errors. Currently, only the generation of `OpenAPI` documentation supports this feature.                                                                                                                                                                                                                                                                               |
 |                                `enumConvertor`                                 | `3.1.0` |    ❌     | `Boolean`      |       `false`       | In the header/path/query request mode, whether to enable the enumeration converter, The default value is false. <br/>If true, the enumeration value is parsed as an enumeration example value. <br/>If false, take the enumeration name as the enumeration example value                                                                                                                                                                                                                                                     |
+|                  [`openApiTagNameType`](#openapitagnametype)                   | `3.1.1` |    ❌     | `String`       |    `CLASS_NAME`     | Determines how to generate tag names (`tags[].name`) in the OpenAPI document. Possible values: <ul><li>`CLASS_NAME` (default): Use the controller's simple class name.</li><li>`DESCRIPTION`: Use the controller's description.</li><li>`PACKAGE_NAME`: Use the controller's full package name.</li></ul> This setting controls how API operations are grouped in the OpenAPI documentation.                                                                                                                                 | 定义 OpenAPI 文档中 `tags[].name` 的生成策略。可选值：<ul><li>`CLASS_NAME`（默认）：使用控制器的简单类名。</li><li>`DESCRIPTION`：使用控制器的描述信息。</li><li>`PACKAGE_NAME`：使用控制器的完整包路径。</li></ul> 此设置影响 API 操作在 OpenAPI 文档中的分组方式。 |
 
 ```json
 {
@@ -248,7 +249,8 @@
         "addPrometheusListener": true
     },
     "addDefaultHttpStatuses": true,
-    "enumConvertor": false
+    "enumConvertor": false,
+    "openApiTagNameType": "CLASS_NAME"
 }
 ```
 ## packageFilters
@@ -271,7 +273,36 @@
 }
 ```
 
+If the interface filtering result does not meet expectations after configuration, the issue might be in the regular expression setup. You can manually invoke the `DocUtil` tool in `smart-doc` to verify your regex.
 
+Refer to the following example for validation:
+
+```
+    /**
+     * test packageFilters pattern
+     */
+    @Test
+    void testIsMatchPattern() {
+        String classOne = "xxx.yyy.zzz.Controller";
+        String classTwo = "xxx.yyy.zzz222.TestController";
+
+        // Match only classes under com.example
+        String packageFiltersOne = "^xxx\\.yyy\\.zzz\\..*$";
+        boolean result1 = DocUtil.isMatch(packageFiltersOne, classOne);
+        boolean result2 = DocUtil.isMatch(packageFiltersOne, classTwo);
+
+        assertTrue(result1);
+        assertFalse(result2);
+
+        // Greedy regex with .*
+        String packageFiltersTwo = "xxx.yyy.zzz.*";
+        boolean result3 = DocUtil.isMatch(packageFiltersTwo, classOne);
+        boolean result4 = DocUtil.isMatch(packageFiltersTwo, classTwo);
+
+        assertTrue(result3);
+        assertTrue(result4);
+    }
+```
 
 
 
@@ -532,7 +563,7 @@ public void testIsMatch() {
     System.out.println(DocUtil.isMatch(pattern, controllerName));
 }
 ```
-## jmeter
+## jmeter    <Badge type="tip" text="^3.0.4" />
 Starting from version `3.0.4`, the following custom configuration options have been added when generating `JMeter` performance test scripts:
 
 | Configuration           | Type      | Description                                                       |
@@ -547,7 +578,45 @@ Starting from version `3.0.4`, the following custom configuration options have b
 }
 ```
 
+## openApiTagNameType <Badge type="tip" text="^3.1.1" />
 
+Added in version `3.1.1`, this configuration controls the **generation strategy for `tags[].name` in OpenAPI documents**. It allows flexible definition of how API interfaces are grouped in the documentation.
+
+### ✅ Configuration Details
+
+| Configuration        | Type     | Description                                                                                                                                                                                                                                                                                                                                                                                |
+|----------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `openApiTagNameType` | `String` | Specifies the tag name generation method. Supported enumeration values:<br> - `CLASS_NAME` (default): Uses the controller class name as the tag name (e.g., `UserController`)<br> - `DESCRIPTION`: Uses the controller description as the tag name (e.g., `User Management Interface`)<br> - `PACKAGE_NAME`: Uses the full package path of the controller (e.g., `com.example.controller`) |
+
+### 📄 Example Configuration
+
+```json
+{
+  "openApiTagNameType": "DESCRIPTION"
+}
+```
+
+### 📌 Usage Guide
+
+- **CLASS_NAME**  
+  Uses the controller class name directly as the tag name. Suitable for basic scenarios.  
+  Example: `UserController` → Tag name `UserController`
+
+- **DESCRIPTION**  
+  Uses the controller's description
+  Example: Description set to `User Management Interface` → Tag name `User Management Interface`
+
+- **PACKAGE_NAME**  
+  Uses the full package path as the tag name. Ideal for modular organization in large projects.  
+  Example: Package path `com.example.controller.user` → Tag name `com.example.controller.user`
+
+### 🧩 Recommended Scenarios
+
+| Scenario                            | Recommended Configuration | Description                           |
+|-------------------------------------|---------------------------|---------------------------------------|
+| Quickly generate base documentation | `CLASS_NAME`              | No extra configuration required       |
+| Use user-friendly tag names         | `DESCRIPTION`             | Leverage controller descriptions      |
+| Organize documentation by module    | `PACKAGE_NAME`            | Logical grouping by package structure |
 
 
 

--- a/docs/zh/guide/advanced/config.md
+++ b/docs/zh/guide/advanced/config.md
@@ -4,71 +4,72 @@
 
 ## 完整配置
 
-|                              配置                               |   版本    | 必填 |       类型       |         默认值         | 描述                                                                                                                                                                                                                         |
-|:-------------------------------------------------------------:|:-------:|:--:|:--------------:|:-------------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|                           `outPath`                           |         | ✔  |    `String`    |                     | 指定文档的输出路径                                                                                                                                                                                                                  |
-|                          `serverUrl`                          |         | ❌  |    `String`    | `http://127.0.0.1`  | 服务器地址, 导出`postman`建议设置成`http://{{server}}`方便直接在`postman`直接设置环境变量。 `2.4.8`后导出`postman`建议使用`serverEnv`,避免多出导出时修改配置。                                                                                                          |
-|                          `serverEnv`                          | `2.4.8` | ❌  |    `String`    |                     | 服务器地址, 导出`postman`建议设置成`http://{{server}}`方便直接在`postman`直接设置环境变量。改配置是为了支持postman导出时不用全局修改`serverUrl`                                                                                                                       |
-|                         `pathPrefix`                          | `2.2.3` | ❌  |    `String`    |                     | 设置`path`前缀, 如配置`Servlet ContextPath`。                                                                                                                                                                                      |
-|                          `isStrict`                           |         | ❌  |   `Boolean`    |                     | 是否开启严格模式,严格模式会强制检查代码注释，在`2.6.3`即以后的插件版本设置此项时检查到注释错误也会直接中断插件白嵌套的构建周期。 作为团队使用建议使用设置为`true`，提升对开发人员的注释要求，提升文档的完善度。                                                                                                            |
-|                          `allInOne`                           |         | ❌  |   `Boolean`    |       `false`       | 是否将文档合并到一个文件中，一般推荐为`true`。                                                                                                                                                                                                 |
-|                          `coverOld`                           |         | ❌  |   `Boolean`    |       `false`       | 是否覆盖旧的文件，主要用于`Markdown`文件覆盖。                                                                                                                                                                                               |
-|                       `createDebugPage`                       | `2.0.1` | ❌  |   `Boolean`    |       `false`       | `smart-doc`支持创一个类似`Swagger`那种可调试接口的`HTML`文档页面，仅在`AllInOne`模式中起作用。 从@2.0.1开始，对html文档，无论是allInOne还是非allInOne模式都能够生成debug页面。                                                                                                  |
-|              [`packageFilters`](#packagefilters)              |         | ❌  |    `String`    |                     | `Controller`包过滤，多个包用英文逗号隔开。<br />`2.2.2`开始需要采用正则：`com.test.controller.*` <br />`2.7.1`开始支持方法级别正则：`com.test.controller.TestController.*`                                                                                    |
-|                    `packageExcludeFilters`                    |         | ❌  |    `String`    |                     | 对`packageFilters`排除子包，多个包用英文逗号隔开<br />`2.2.2`开始需要采用正则：`com.test.controller.res.*`                                                                                                                                          |
-|                    `md5EncryptedHtmlName`                     |         | ❌  |   `Boolean`    |       `false`       | 只有每个`Controller`生成一个`HTML`文件是才使用。                                                                                                                                                                                          |
-|                            `style`                            |         | ❌  |    `String`    |                     | 基于`highlight.js`的[代码高亮](https://highlightjs.org/)设置。                                                                                                                                                                       |
-|                         `projectName`                         |         | ❌  |    `String`    |                     | 只有每个`Controller`生成一个`HTML`文件是才使用。 如果`smart-doc.json`中和插件中都未设置`projectName`，`2.3.4`开始，插件自动采用`pom`中的`projectName`作为默认填充， 因此使用插件时可以不配置。                                                                                       |
-|                     `skipTransientField`                      | `1.7.8` | ❌  |   `Boolean`    |       `true`        | 自 3.0.8 起已弃用。请使用 `serializeRequestTransients` 和 `serializeResponseTransients` 代替。此配置用于跳过请求和响应体中瞬态字段的序列化。                                                                                                                   |
-|                 `serializeRequestTransients`                  | `3.0.8` | ❌  |   `Boolean`    |       `false`       | 决定是否序列化请求对象中的瞬态字段。设置为 `true` 时，`transient`修饰的字段将包含在请求序列化中。                                                                                                                                                                 |
-|                 `serializeResponseTransients`                 | `3.0.8` | ❌  |   `Boolean`    |       `false`       | 决定是否序列化响应对象中的瞬态字段。设置为 `true` 时，`transient`修饰的字段将包含在响应序列化中。                                                                                                                                                                 |
-|                         `sortByTitle`                         | `1.8.7` | ❌  |   `Boolean`    |       `false`       | 接口标题排序。                                                                                                                                                                                                                    |
-|                         `showAuthor`                          |         | ❌  |   `Boolean`    |       `true`        | 是否显示接口作者名称。                                                                                                                                                                                                                |
-|                   `requestFieldToUnderline`                   | `1.8.7` | ❌  |   `Boolean`    |       `false`       | 自动将驼峰入参字段在文档中转为下划线格式。                                                                                                                                                                                                      |
-|                  `responseFieldToUnderline`                   | `1.8.7` | ❌  |   `Boolean`    |       `false`       | 自动将驼峰响应字段在文档中转为下划线格式。                                                                                                                                                                                                      |
-|                         `inlineEnum`                          | `1.8.8` | ❌  |   `Boolean`    |       `false`       | 是否将枚举详情展示到参数表中。                                                                                                                                                                                                            |
-|                       `recursionLimit`                        | `1.8.8` | ❌  |     `int`      |         `7`         | 设置允许递归执行的次数用于避免一些对象解析卡主。                                                                                                                                                                                                   |
-|                     `allInOneDocFileName`                     | `1.9.0` | ❌  |    `String`    |    `index.html`     | 只有配置项目所有`Controller`生成一个`HTML`文件时才生效。                                                                                                                                                                                      |
-|                       `requestExample`                        | `1.9.0` | ❌  |   `Boolean`    |       `true`        | 是否将请求示例展示在文档中。                                                                                                                                                                                                             |
-|                       `responseExample`                       | `1.9.0` | ❌  |   `Boolean`    |       `true`        | 是否将响应示例展示在文档中。                                                                                                                                                                                                             |
-|                          `urlSuffix`                          | `2.1.0` | ❌  |    `String`    |                     | 支持`SpringMVC`旧项目的`url`后缀。                                                                                                                                                                                                  |
-|                          `language`                           |         | ❌  |    `String`    |      `CHINESE`      | mock值的国际化支持。                                                                                                                                                                                                               |
-|                      `displayActualType`                      | `1.9.6` | ❌  |   `Boolean`    |       `false`       | 是否在注释栏自动显示泛型的真实类型短类名。                                                                                                                                                                                                      |
-|                           `appKey`                            | `2.0.9` | ❌  |    `String`    |                     | `torna`平台对接`appKey`。                                                                                                                                                                                                       |
-|                          `appToken`                           | `2.0.9` | ❌  |    `String`    |                     | `torna`平台`appToken`。                                                                                                                                                                                                       |
-|                           `secret`                            | `2.0.9` | ❌  |    `String`    |                     | `torna`平台`secret`。                                                                                                                                                                                                         |
-|                           `openUrl`                           | `2.0.9` | ❌  |    `String`    |                     | `torna`平台地址，填写自己的私有化部署地址。                                                                                                                                                                                                  |
-|                        `debugEnvName`                         |         | ❌  |    `String`    |                     | `torna`环境名称。                                                                                                                                                                                                               |
-|                           `replace`                           | `2.2.4` | ❌  |   `Boolean`    |       `true`        | 推送`torna`时替换旧的文档。改动还是会推送过去覆盖的，这个功能主要是保证代码删除了，`torna`上没有删除。                                                                                                                                                                 |
-|                         `debugEnvUrl`                         | `2.0.9` | ❌  |    `String`    |                     | 推送`torna`配置接口服务地址。                                                                                                                                                                                                         |
-|                         `tornaDebug`                          | `2.0.9` | ❌  |   `Boolean`    |       `true`        | 是否打印`torna`推送日志。                                                                                                                                                                                                           |
-|                           `author`                            | `2.0.9` | ❌  |    `String`    |                     | 指定推送到Torna的用户名                                                                                                                                                                                                             |
-|                     `ignoreRequestParams`                     | `1.9.2` | ❌  | `List<String>` |                     | 忽略请求参数对象，把不想生成文档的参数对象屏蔽掉。                                                                                                                                                                                                  |
-|            [`dataDictionaries`](#datadictionaries)            |         | ❌  | `List<Object>` |                     | 配置数据字典<br />`2.4.6`开始可以配置枚举实现的接口， 当配置接口时title将使用实现枚举的类描述，如果有已经实现的枚举需要忽略的话，可以在实现枚举类上增加`@ignore`进行忽略。                                                                                                                        |
-|       [`errorCodeDictionaries`](#errorcodedictionaries)       |         | ❌  | `List<Object>` |                     | 错误码列表<br />`2.4.6`开始可以配置枚举实现的接口， 当配置接口时title将使用实现枚举的类描述，如果有已经实现的枚举需要忽略的话，可以在实现枚举类上增加`@ignore`进行忽略。                                                                                                                         |
-|                [`revisionLogs`](#revisionlogs)                |         | ❌  | `List<Object>` |                     | 文档变更记录。                                                                                                                                                                                                                    |
-|        [`customResponseFields`](#customresponsefields)        |         | ❌  | `List<Object>` |                     | 自定义添加字段和注释，一般用户处理第三方`jar`包库。                                                                                                                                                                                               |
-|         [`customRequestFields`](#customrequestfields)         |         | ❌  | `List<Object>` |                     | 自定义请求体的注释。                                                                                                                                                                                                                 |
-| [`requestHeaders`](/zh/guide/advanced/advancedFeatures#公共请求头) | `2.1.3` | ❌  | `List<Object>` |                     | 设置公共请求头。                                                                                                                                                                                                                   |
-| [`requestParams`](/zh/guide/advanced/advancedFeatures#公共请求参数) | `2.2.3` | ❌  | `List<Object>` |                     | 公共请求参数(通过拦截器处理的场景)。                                                                                                                                                                                                        |
-|          [`rpcApiDependencies`](#rpcapidependencies)          |         | ❌  | `List<Object>` |                     | 项目开放的`Dubbo API`接口模块依赖，配置后输出到文档方便使用者集成。                                                                                                                                                                                    |
-|                      `rpcConsumerConfig`                      |         | ❌  |    `String`    |                     | 文档中添加`Dubbo Consumer`集成配置，用于方便集成方可以快速集成。                                                                                                                                                                                   |
-|       [`apiObjectReplacements`](#apiobjectreplacements)       | `1.8.5` | ❌  | `List<Object>` |                     | 使用自定义类覆盖其他类做文档渲染。                                                                                                                                                                                                          |
-| [`apiConstants`](/zh/guide/advanced/advancedFeatures#静态常量替换)  | `1.8.9` | ❌  | `List<Object>` |                     | 配置自己的常量类，`smart-doc`在解析到常量时自动替换为具体的值。 `2.4.2`版本开始使用到常量也无需配置，`smart-doc`已经能够自动解析。                                                                                                                                           |
-|          [`responseBodyAdvice`](#responsebodyadvice)          | `1.8.9` | ❌  | `List<Object>` |                     | `ResponseBodyAdvice`是`Spring`框架中预留的钩子，它作用在`Controller`方法执行完成之后，`http`响应体写回客户端之前， 它能方便的织入一些自己的业务逻辑处理了，因此`smart-doc`也提供了对`ResponseBodyAdvice`统一返回设置(不要随便配置根据项目的技术来配置)支持， 可用`ignoreResponseBodyAdvice` tag来忽略。                |
-|           [`requestBodyAdvice`](#requestbodyadvice)           | `2.1.4` | ❌  | `List<Object>` |                     | 设置`RequestBodyAdvice`统一请求包装类。                                                                                                                                                                                              |
-|                      [`groups`](#groups)                      | `2.2.5` | ❌  | `List<Object>` |                     | 对不同的`Controller`进行分组。                                                                                                                                                                                                      |
-|                     `requestParamsTable`                      | `2.2.5` | ❌  |    `String`    |                     | 是否将请求参数表展示在文档中。                                                                                                                                                                                                            |
-|                     `responseParamsTable`                     | `2.2.5` | ❌  |   `Boolean`    |                     | 是否将响应参数表展示在文档中。                                                                                                                                                                                                            |
-|                          `framework`                          | `2.2.5` | ❌  |    `String`    | `spring` or `dubbo` | `Spring`和`Apache Dubbo`是`smart-doc`默认支持解析生成文档的框架，不配置`framework`时根据触发的文档构建场景自动选择`Spring`或者 `Dubbo`，`smart-doc`目前也支持`JAX-RS`的标准，因此使用支持`JAX-RS`标准的框架(如：`Quarkus`)可以作为体验使用，但是还不完善。<br />可选值: `spring`,`dubbo`,`JAX-RS`,`solon` |
-|                         `randomMock`                          | `2.6.9` | ❌  |   `Boolean`    |       `false`       | `randomMock`用于控制是否让`smart-doc`生成随机`mock`值，在`2.6.9`之前的版本中`smart-doc`会自动给参数和自动生成随机值， 每次生成的值都不一样，现在你可以设置为`false`来控制随机值的生成。                                                                                                    |
-|                        `componentType`                        | `2.7.8` | ❌  |    `String`    |      `RANDOM`       | `openapi component key generator`<br />`RANDOM` : 支持 `@Validated` 分组校验 <br />`NORMAL`: 不支持 `@Validated`, 用于 `openapi` 生成代码                                                                                                 |
-|                          `increment`                          | `3.0.0` | ❌  |   `Boolean`    |       `false`       | `increment`用于控制是否让`smart-doc`根据`GIT`代码的变更实现文档的增量推送                                                                                                                                                                         |
-|                        `apiUploadNums`                        | `3.0.2` | ❌  |   `Integer`    |                     | 上传`torna`时，支持文档分批上传，设置文档批次的大小。不配置则一次上传所有                                                                                                                                                                                   |
-|                       `showValidation`                        | `3.0.3` | ❌  |   `Boolean`    |       `true`        | `showValidation`用于控制`smart-doc`是否提取JSR字段验证信息展示到文档中                                                                                                                                                                         |
-|                           `jmeter`                            | `3.0.4` | ❌  |    `Object`    |                     | 生成`JMeter`性能测试脚本一些配置。                                                                                                                                                                                                      |
-|                   `addDefaultHttpStatuses`                    | `3.0.5` | ❌  |   `Boolean`    |       `false`       | 生成文档时是否添加框架默认的`http`状态码，例如`Spring MVC`默认的`500`和`404`, 当前只有生成`OenAPI`文档时支持。                                                                                                                                                 |
-|                        `enumConvertor`                        | `3.1.0` | ❌  |   `Boolean`    |       `false`       | 在 header/path/query 请求类型下，是否启用枚举转换器，默认值为false。<br/>如果为true，则解析enumValue作为枚举示例值。<br/>如果为false，则以enumName作为枚举示例值                                                                                                             |
+|                              配置                               |   版本    | 必填 |       类型       |         默认值         | 描述                                                                                                                                                                                                                                                   |
+|:-------------------------------------------------------------:|:-------:|:--:|:--------------:|:-------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|                           `outPath`                           |         | ✔  |    `String`    |                     | 指定文档的输出路径                                                                                                                                                                                                                                            |
+|                          `serverUrl`                          |         | ❌  |    `String`    | `http://127.0.0.1`  | 服务器地址, 导出`postman`建议设置成`http://{{server}}`方便直接在`postman`直接设置环境变量。 `2.4.8`后导出`postman`建议使用`serverEnv`,避免多出导出时修改配置。                                                                                                                                    |
+|                          `serverEnv`                          | `2.4.8` | ❌  |    `String`    |                     | 服务器地址, 导出`postman`建议设置成`http://{{server}}`方便直接在`postman`直接设置环境变量。改配置是为了支持postman导出时不用全局修改`serverUrl`                                                                                                                                                 |
+|                         `pathPrefix`                          | `2.2.3` | ❌  |    `String`    |                     | 设置`path`前缀, 如配置`Servlet ContextPath`。                                                                                                                                                                                                                |
+|                          `isStrict`                           |         | ❌  |   `Boolean`    |                     | 是否开启严格模式,严格模式会强制检查代码注释，在`2.6.3`即以后的插件版本设置此项时检查到注释错误也会直接中断插件白嵌套的构建周期。 作为团队使用建议使用设置为`true`，提升对开发人员的注释要求，提升文档的完善度。                                                                                                                                      |
+|                          `allInOne`                           |         | ❌  |   `Boolean`    |       `false`       | 是否将文档合并到一个文件中，一般推荐为`true`。                                                                                                                                                                                                                           |
+|                          `coverOld`                           |         | ❌  |   `Boolean`    |       `false`       | 是否覆盖旧的文件，主要用于`Markdown`文件覆盖。                                                                                                                                                                                                                         |
+|                       `createDebugPage`                       | `2.0.1` | ❌  |   `Boolean`    |       `false`       | `smart-doc`支持创一个类似`Swagger`那种可调试接口的`HTML`文档页面，仅在`AllInOne`模式中起作用。 从@2.0.1开始，对html文档，无论是allInOne还是非allInOne模式都能够生成debug页面。                                                                                                                            |
+|              [`packageFilters`](#packagefilters)              |         | ❌  |    `String`    |                     | `Controller`包过滤，多个包用英文逗号隔开。<br />`2.2.2`开始需要采用正则：`com.test.controller.*` <br />`2.7.1`开始支持方法级别正则：`com.test.controller.TestController.*`                                                                                                              |
+|                    `packageExcludeFilters`                    |         | ❌  |    `String`    |                     | 对`packageFilters`排除子包，多个包用英文逗号隔开<br />`2.2.2`开始需要采用正则：`com.test.controller.res.*`                                                                                                                                                                    |
+|                    `md5EncryptedHtmlName`                     |         | ❌  |   `Boolean`    |       `false`       | 只有每个`Controller`生成一个`HTML`文件是才使用。                                                                                                                                                                                                                    |
+|                            `style`                            |         | ❌  |    `String`    |                     | 基于`highlight.js`的[代码高亮](https://highlightjs.org/)设置。                                                                                                                                                                                                 |
+|                         `projectName`                         |         | ❌  |    `String`    |                     | 只有每个`Controller`生成一个`HTML`文件是才使用。 如果`smart-doc.json`中和插件中都未设置`projectName`，`2.3.4`开始，插件自动采用`pom`中的`projectName`作为默认填充， 因此使用插件时可以不配置。                                                                                                                 |
+|                     `skipTransientField`                      | `1.7.8` | ❌  |   `Boolean`    |       `true`        | 自 3.0.8 起已弃用。请使用 `serializeRequestTransients` 和 `serializeResponseTransients` 代替。此配置用于跳过请求和响应体中瞬态字段的序列化。                                                                                                                                             |
+|                 `serializeRequestTransients`                  | `3.0.8` | ❌  |   `Boolean`    |       `false`       | 决定是否序列化请求对象中的瞬态字段。设置为 `true` 时，`transient`修饰的字段将包含在请求序列化中。                                                                                                                                                                                           |
+|                 `serializeResponseTransients`                 | `3.0.8` | ❌  |   `Boolean`    |       `false`       | 决定是否序列化响应对象中的瞬态字段。设置为 `true` 时，`transient`修饰的字段将包含在响应序列化中。                                                                                                                                                                                           |
+|                         `sortByTitle`                         | `1.8.7` | ❌  |   `Boolean`    |       `false`       | 接口标题排序。                                                                                                                                                                                                                                              |
+|                         `showAuthor`                          |         | ❌  |   `Boolean`    |       `true`        | 是否显示接口作者名称。                                                                                                                                                                                                                                          |
+|                   `requestFieldToUnderline`                   | `1.8.7` | ❌  |   `Boolean`    |       `false`       | 自动将驼峰入参字段在文档中转为下划线格式。                                                                                                                                                                                                                                |
+|                  `responseFieldToUnderline`                   | `1.8.7` | ❌  |   `Boolean`    |       `false`       | 自动将驼峰响应字段在文档中转为下划线格式。                                                                                                                                                                                                                                |
+|                         `inlineEnum`                          | `1.8.8` | ❌  |   `Boolean`    |       `false`       | 是否将枚举详情展示到参数表中。                                                                                                                                                                                                                                      |
+|                       `recursionLimit`                        | `1.8.8` | ❌  |     `int`      |         `7`         | 设置允许递归执行的次数用于避免一些对象解析卡主。                                                                                                                                                                                                                             |
+|                     `allInOneDocFileName`                     | `1.9.0` | ❌  |    `String`    |    `index.html`     | 只有配置项目所有`Controller`生成一个`HTML`文件时才生效。                                                                                                                                                                                                                |
+|                       `requestExample`                        | `1.9.0` | ❌  |   `Boolean`    |       `true`        | 是否将请求示例展示在文档中。                                                                                                                                                                                                                                       |
+|                       `responseExample`                       | `1.9.0` | ❌  |   `Boolean`    |       `true`        | 是否将响应示例展示在文档中。                                                                                                                                                                                                                                       |
+|                          `urlSuffix`                          | `2.1.0` | ❌  |    `String`    |                     | 支持`SpringMVC`旧项目的`url`后缀。                                                                                                                                                                                                                            |
+|                          `language`                           |         | ❌  |    `String`    |      `CHINESE`      | mock值的国际化支持。                                                                                                                                                                                                                                         |
+|                      `displayActualType`                      | `1.9.6` | ❌  |   `Boolean`    |       `false`       | 是否在注释栏自动显示泛型的真实类型短类名。                                                                                                                                                                                                                                |
+|                           `appKey`                            | `2.0.9` | ❌  |    `String`    |                     | `torna`平台对接`appKey`。                                                                                                                                                                                                                                 |
+|                          `appToken`                           | `2.0.9` | ❌  |    `String`    |                     | `torna`平台`appToken`。                                                                                                                                                                                                                                 |
+|                           `secret`                            | `2.0.9` | ❌  |    `String`    |                     | `torna`平台`secret`。                                                                                                                                                                                                                                   |
+|                           `openUrl`                           | `2.0.9` | ❌  |    `String`    |                     | `torna`平台地址，填写自己的私有化部署地址。                                                                                                                                                                                                                            |
+|                        `debugEnvName`                         |         | ❌  |    `String`    |                     | `torna`环境名称。                                                                                                                                                                                                                                         |
+|                           `replace`                           | `2.2.4` | ❌  |   `Boolean`    |       `true`        | 推送`torna`时替换旧的文档。改动还是会推送过去覆盖的，这个功能主要是保证代码删除了，`torna`上没有删除。                                                                                                                                                                                           |
+|                         `debugEnvUrl`                         | `2.0.9` | ❌  |    `String`    |                     | 推送`torna`配置接口服务地址。                                                                                                                                                                                                                                   |
+|                         `tornaDebug`                          | `2.0.9` | ❌  |   `Boolean`    |       `true`        | 是否打印`torna`推送日志。                                                                                                                                                                                                                                     |
+|                           `author`                            | `2.0.9` | ❌  |    `String`    |                     | 指定推送到Torna的用户名                                                                                                                                                                                                                                       |
+|                     `ignoreRequestParams`                     | `1.9.2` | ❌  | `List<String>` |                     | 忽略请求参数对象，把不想生成文档的参数对象屏蔽掉。                                                                                                                                                                                                                            |
+|            [`dataDictionaries`](#datadictionaries)            |         | ❌  | `List<Object>` |                     | 配置数据字典<br />`2.4.6`开始可以配置枚举实现的接口， 当配置接口时title将使用实现枚举的类描述，如果有已经实现的枚举需要忽略的话，可以在实现枚举类上增加`@ignore`进行忽略。                                                                                                                                                  |
+|       [`errorCodeDictionaries`](#errorcodedictionaries)       |         | ❌  | `List<Object>` |                     | 错误码列表<br />`2.4.6`开始可以配置枚举实现的接口， 当配置接口时title将使用实现枚举的类描述，如果有已经实现的枚举需要忽略的话，可以在实现枚举类上增加`@ignore`进行忽略。                                                                                                                                                   |
+|                [`revisionLogs`](#revisionlogs)                |         | ❌  | `List<Object>` |                     | 文档变更记录。                                                                                                                                                                                                                                              |
+|        [`customResponseFields`](#customresponsefields)        |         | ❌  | `List<Object>` |                     | 自定义添加字段和注释，一般用户处理第三方`jar`包库。                                                                                                                                                                                                                         |
+|         [`customRequestFields`](#customrequestfields)         |         | ❌  | `List<Object>` |                     | 自定义请求体的注释。                                                                                                                                                                                                                                           |
+| [`requestHeaders`](/zh/guide/advanced/advancedFeatures#公共请求头) | `2.1.3` | ❌  | `List<Object>` |                     | 设置公共请求头。                                                                                                                                                                                                                                             |
+| [`requestParams`](/zh/guide/advanced/advancedFeatures#公共请求参数) | `2.2.3` | ❌  | `List<Object>` |                     | 公共请求参数(通过拦截器处理的场景)。                                                                                                                                                                                                                                  |
+|          [`rpcApiDependencies`](#rpcapidependencies)          |         | ❌  | `List<Object>` |                     | 项目开放的`Dubbo API`接口模块依赖，配置后输出到文档方便使用者集成。                                                                                                                                                                                                              |
+|                      `rpcConsumerConfig`                      |         | ❌  |    `String`    |                     | 文档中添加`Dubbo Consumer`集成配置，用于方便集成方可以快速集成。                                                                                                                                                                                                             |
+|       [`apiObjectReplacements`](#apiobjectreplacements)       | `1.8.5` | ❌  | `List<Object>` |                     | 使用自定义类覆盖其他类做文档渲染。                                                                                                                                                                                                                                    |
+| [`apiConstants`](/zh/guide/advanced/advancedFeatures#静态常量替换)  | `1.8.9` | ❌  | `List<Object>` |                     | 配置自己的常量类，`smart-doc`在解析到常量时自动替换为具体的值。 `2.4.2`版本开始使用到常量也无需配置，`smart-doc`已经能够自动解析。                                                                                                                                                                     |
+|          [`responseBodyAdvice`](#responsebodyadvice)          | `1.8.9` | ❌  | `List<Object>` |                     | `ResponseBodyAdvice`是`Spring`框架中预留的钩子，它作用在`Controller`方法执行完成之后，`http`响应体写回客户端之前， 它能方便的织入一些自己的业务逻辑处理了，因此`smart-doc`也提供了对`ResponseBodyAdvice`统一返回设置(不要随便配置根据项目的技术来配置)支持， 可用`ignoreResponseBodyAdvice` tag来忽略。                                          |
+|           [`requestBodyAdvice`](#requestbodyadvice)           | `2.1.4` | ❌  | `List<Object>` |                     | 设置`RequestBodyAdvice`统一请求包装类。                                                                                                                                                                                                                        |
+|                      [`groups`](#groups)                      | `2.2.5` | ❌  | `List<Object>` |                     | 对不同的`Controller`进行分组。                                                                                                                                                                                                                                |
+|                     `requestParamsTable`                      | `2.2.5` | ❌  |    `String`    |                     | 是否将请求参数表展示在文档中。                                                                                                                                                                                                                                      |
+|                     `responseParamsTable`                     | `2.2.5` | ❌  |   `Boolean`    |                     | 是否将响应参数表展示在文档中。                                                                                                                                                                                                                                      |
+|                          `framework`                          | `2.2.5` | ❌  |    `String`    | `spring` or `dubbo` | `Spring`和`Apache Dubbo`是`smart-doc`默认支持解析生成文档的框架，不配置`framework`时根据触发的文档构建场景自动选择`Spring`或者 `Dubbo`，`smart-doc`目前也支持`JAX-RS`的标准，因此使用支持`JAX-RS`标准的框架(如：`Quarkus`)可以作为体验使用，但是还不完善。<br />可选值: `spring`,`dubbo`,`JAX-RS`,`solon`                           |
+|                         `randomMock`                          | `2.6.9` | ❌  |   `Boolean`    |       `false`       | `randomMock`用于控制是否让`smart-doc`生成随机`mock`值，在`2.6.9`之前的版本中`smart-doc`会自动给参数和自动生成随机值， 每次生成的值都不一样，现在你可以设置为`false`来控制随机值的生成。                                                                                                                              |
+|                        `componentType`                        | `2.7.8` | ❌  |    `String`    |      `RANDOM`       | `openapi component key generator`<br />`RANDOM` : 支持 `@Validated` 分组校验 <br />`NORMAL`: 不支持 `@Validated`, 用于 `openapi` 生成代码                                                                                                                           |
+|                          `increment`                          | `3.0.0` | ❌  |   `Boolean`    |       `false`       | `increment`用于控制是否让`smart-doc`根据`GIT`代码的变更实现文档的增量推送                                                                                                                                                                                                   |
+|                        `apiUploadNums`                        | `3.0.2` | ❌  |   `Integer`    |                     | 上传`torna`时，支持文档分批上传，设置文档批次的大小。不配置则一次上传所有                                                                                                                                                                                                             |
+|                       `showValidation`                        | `3.0.3` | ❌  |   `Boolean`    |       `true`        | `showValidation`用于控制`smart-doc`是否提取JSR字段验证信息展示到文档中                                                                                                                                                                                                   |
+|                           `jmeter`                            | `3.0.4` | ❌  |    `Object`    |                     | 生成`JMeter`性能测试脚本一些配置。                                                                                                                                                                                                                                |
+|                   `addDefaultHttpStatuses`                    | `3.0.5` | ❌  |   `Boolean`    |       `false`       | 生成文档时是否添加框架默认的`http`状态码，例如`Spring MVC`默认的`500`和`404`, 当前只有生成`OenAPI`文档时支持。                                                                                                                                                                           |
+|                        `enumConvertor`                        | `3.1.0` | ❌  |   `Boolean`    |       `false`       | 在 header/path/query 请求类型下，是否启用枚举转换器，默认值为false。<br/>如果为true，则解析enumValue作为枚举示例值。<br/>如果为false，则以enumName作为枚举示例值                                                                                                                                       |
+|          [`openApiTagNameType`](#openapitagnametype)          | `3.1.1` | ❌  |    `String`    |    `CLASS_NAME`     | 定义 OpenAPI 文档中 `tags[].name` 的生成策略。<br/> 可选值：<br/> - `CLASS_NAME`（默认）：使用控制器的简单类名（如 `UserController`）。<br/> - `DESCRIPTION`：使用控制器的描述信息（如 `用户管理`）。<br/> - `PACKAGE_NAME`：使用控制器的完整包路径（如 `com.example.controller`）。<br/> 此设置影响 API 操作在 OpenAPI 文档中的分组方式。 |
 
 ```json
 {
@@ -252,7 +253,8 @@
         "addPrometheusListener": true
     },
     "addDefaultHttpStatuses": true,
-    "enumConvertor": false
+    "enumConvertor": false,
+    "openApiTagNameType": "CLASS_NAME"
 }
 ```
 
@@ -262,7 +264,9 @@
 
 `Controller`包过滤，多个包用英文逗号隔开。
 
-> PS: 2.2.2开始需要采用正则：com.test.controller.* ，2.7.1开始支持方法级别正则：com.test.controller.TestController.*
+> PS: <br>
+> 2.2.2 开始需要采用正则：com.test.controller.* <br>
+> 2.7.1 开始支持方法级别正则：com.test.controller.TestController.*
 
 ```json
 {
@@ -277,6 +281,38 @@
     "packageFilters": "com.example.controller.PetController.*Info", // 只输出 PetController 类中以 Info 为方法名结尾的所有接口
     "packageFilters": "com.example.controller.PetController.get.*Info", // 只输出 PetController 类中符合 get.*Info 为方法名的所有接口
 }
+```
+
+如果配置后接口过滤结果不符合需求，可能是正则配置有问题。可以自行调用`smart-doc`中`DocUtil`工具验证。
+验证例子参考如下：
+```
+    /**
+	 * test packageFilters pattern
+	 */
+	@Test
+	void testIsMatchPattern() {
+		String classOne = "xxx.yyy.zzz.Controller";
+		String classTwo = "xxx.yyy.zzz222.TestController";
+
+
+		// 只匹配 com.example 下的类
+		String packageFiltersOne = "^xxx\\.yyy\\.zzz\\..*$";
+		boolean result1 = DocUtil.isMatch(packageFiltersOne, classOne);
+		boolean result2 = DocUtil.isMatch(packageFiltersOne, classTwo);
+
+		assertTrue(result1);
+		assertFalse(result2);
+
+
+		// .* 贪婪正则
+		String packageFiltersTwo = "xxx.yyy.zzz.*";
+		boolean result3 = DocUtil.isMatch(packageFiltersTwo, classOne);
+		boolean result4 = DocUtil.isMatch(packageFiltersTwo, classTwo);
+
+		assertTrue(result3);
+		assertTrue(result4);
+
+	}
 ```
 
 
@@ -539,7 +575,7 @@ public void testIsMatch() {
 }
 ```
 
-## jmeter
+## jmeter    <Badge type="tip" text="^3.0.4" />
 
 `3.0.4`版本开始增加，生成`JMeter`性能测试脚本时的自定义配置项
 
@@ -555,9 +591,45 @@ public void testIsMatch() {
 }
 ```
 
+## openApiTagNameType     <Badge type="tip" text="^3.1.1" />
 
+`3.1.1`版本开始新增，用于控制生成 OpenAPI 文档时 `tags[].name` 的生成策略。通过该配置可灵活定义 API 接口在文档中的分组标识。
 
+### ✅ 配置说明
 
+| 配置项                  | 类型       | 描述                                                                                                                                                                                          |
+|----------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `openApiTagNameType` | `String` | 指定标签名称生成方式，支持以下枚举值：<br> - `CLASS_NAME`（默认）：使用控制器类名作为标签名（如 `UserController`）<br> - `DESCRIPTION`：使用控制器描述信息作为标签名（如 `用户管理接口`）<br> - `PACKAGE_NAME`：使用控制器完整包路径作为标签名（如 `com.example.controller`） |
+
+### 📄 示例配置
+
+```json
+{
+  "openApiTagNameType": "DESCRIPTION"
+}
+```
+
+### 📌 使用说明
+
+- **CLASS_NAME**  
+  直接取控制器类名作为标签名，适合基础场景。  
+  示例：`UserController` → 标签名 `UserController`
+
+- **DESCRIPTION**  
+  使用控制器的描述信息
+  示例：描述为 `用户管理接口` → 标签名 `用户管理接口`
+
+- **PACKAGE_NAME**  
+  使用控制器所在包路径作为标签名，适用于按模块分组的大型项目。  
+  示例：包路径 `com.example.controller.user` → 标签名 `com.example.controller.user`
+
+### 🧩 适用场景
+
+| 场景       | 推荐配置           | 说明            |
+|----------|----------------|---------------|
+| 快速生成基础文档 | `CLASS_NAME`   | 无需额外配置，直接使用类名 |
+| 需要友好标签名  | `DESCRIPTION`  | 使用控制器的描述信息    |
+| 按模块组织文档  | `PACKAGE_NAME` | 按包路径分组，逻辑清晰   |
 
 
 


### PR DESCRIPTION
feat(config): :sparkles:  add openApiTagNameType configuration for OpenAPI documentation


- Introduce new configuration option `openApiTagNameType` to control tag name generation in OpenAPI documents
- Add detailed documentation for the new configuration in both English and Chinese guides
- Include examples and usage recommendations for different scenarios
- Update configuration samples to demonstrate the new option

[TongchengOpenSource#1060](https://github.com/TongchengOpenSource/smart-doc/pull/1060)